### PR TITLE
Fix for SciPy `simpson` function

### DIFF
--- a/FRion/predict.py
+++ b/FRion/predict.py
@@ -43,6 +43,7 @@ except:
     print('Cannot import RMextract. Continuing import, but will fail if called.')
 from astropy.time import Time,TimeDelta
 import numpy as np
+from scipy.integrate import simpson as simps
 from astropy.coordinates import EarthLocation,SkyCoord,Angle, UnknownSiteException
 import astropy.units as u
 from FRion.correct import find_freq_axis
@@ -385,7 +386,6 @@ def numeric_integration(times,RMs,freq_array):
     Returns: array: time-integrated ionospheric modulation per channel.
     """
 
-    from scipy.integrate import simps
     l2_arr=(C/freq_array)**2
     z=np.exp(2.j*np.outer(l2_arr,RMs))
 

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,8 @@ VERSION = '1.1.3'
 DOWNLOAD_URL = 'https://github.com/Cameron-Van-Eck/FRion/archive/refs/heads/main.zip'
 
 REQUIRED = [
-    'numpy', 'astropy', 'pyephem', 'requests'
-    ]
+    'numpy', 'astropy', 'pyephem', 'requests', 'scipy'
+]
 
 extras_require={}
 


### PR DESCRIPTION
Scipy v1.12 deprecated `scipy.integrated.simps` and it is removed in v1.14. Simple fix is to migrate to the replacement `simpson` function